### PR TITLE
feat(posts): add soft delete support for posts

### DIFF
--- a/src/controllers/postController.ts
+++ b/src/controllers/postController.ts
@@ -34,7 +34,7 @@ export const getPosts = async (req: AuthRequest, res: Response, next: NextFuncti
     const { mood, postType, page = 1, limit = 20 } = req.query;
     const offset = (Number(page) - 1) * Number(limit);
 
-    const where: any = {};
+    const where: any = { isDeleted: false };
     if (mood) where.mood = mood;
     if (postType) where.postType = postType;
 
@@ -108,7 +108,7 @@ export const getPostById = async (req: AuthRequest, res: Response, next: NextFun
       ],
     });
 
-    if (!post) {
+    if (!post || post.isDeleted) {
       throw new AppError('Post not found', 404);
     }
 
@@ -141,7 +141,10 @@ export const deletePost = async (req: AuthRequest, res: Response, next: NextFunc
       throw new AppError('Unauthorized', 403);
     }
 
-    await post.destroy();
+    post.isDeleted = true;
+    post.deletedAt = new Date();
+    await post.save();
+
 
     res.json({ message: 'Post deleted successfully' });
   } catch (error) {

--- a/src/models/Post.ts
+++ b/src/models/Post.ts
@@ -30,6 +30,8 @@ interface PostAttributes {
   audioUrl?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  isDeleted: boolean;
+  deletedAt?: Date;
 }
 
 interface PostCreationAttributes extends Optional<PostAttributes, 'id' | 'createdAt' | 'updatedAt'> {}
@@ -46,6 +48,8 @@ class Post extends Model<PostAttributes, PostCreationAttributes> implements Post
   declare audioUrl?: string;
   declare readonly createdAt: Date;
   declare readonly updatedAt: Date;
+  declare isDeleted: boolean;
+  declare deletedAt?: Date;
 }
 
 Post.init(
@@ -91,6 +95,15 @@ Post.init(
       type: DataTypes.STRING,
       allowNull: true,
     },
+    isDeleted: {
+      type: DataTypes.BOOLEAN,
+      defaultValue: false,
+    },
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+
   },
   {
     sequelize,


### PR DESCRIPTION
This PR implements soft delete functionality for posts as part of Issue #3.

Changes included:
- Added isDeleted and deletedAt fields to the Post model
- Updated post controller to:
  - Exclude deleted posts from feeds
  - Prevent access to deleted posts by ID
  - Soft delete posts instead of hard delete

Out of scope:
- Comments
- Reactions
- Hope Wall
